### PR TITLE
feat: add middleware for automatic 301 redirects from old slugs

### DIFF
--- a/config/slugify.php
+++ b/config/slugify.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+     * HTTP status code used by SlugRedirectMiddleware when redirecting
+     * from a historical slug to the current one.
+     *
+     * 301 — Permanent redirect (recommended for SEO)
+     * 302 — Temporary redirect
+     */
+    'redirect_status' => 301,
+
+];

--- a/src/HasSlugHistory.php
+++ b/src/HasSlugHistory.php
@@ -35,6 +35,22 @@ trait HasSlugHistory
             ->first();
     }
 
+    public function resolveRouteBinding($value, $field = null): ?Model
+    {
+        /** @var string $slugColumn */
+        $slugColumn = $this->getAttributeToSaveSlugTo(); // @phpstan-ignore method.notFound
+
+        $resolveBySlug = $field === null
+            ? $this->getRouteKeyName() === $slugColumn
+            : $field === $slugColumn;
+
+        if ($resolveBySlug) {
+            return static::findBySlugWithHistory((string) $value);
+        }
+
+        return parent::resolveRouteBinding($value, $field);
+    }
+
     /**
      * @return MorphMany<SlugHistory, $this>
      */

--- a/src/Http/Middleware/SlugRedirectMiddleware.php
+++ b/src/Http/Middleware/SlugRedirectMiddleware.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oliwol\Slugify\Http\Middleware;
+
+use Closure;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Oliwol\Slugify\HasSlugHistory;
+use Symfony\Component\HttpFoundation\Response;
+
+final class SlugRedirectMiddleware
+{
+    /**
+     * @param  Closure(Request): Response  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $route = $request->route();
+
+        foreach ($route->parameters() as $paramName => $model) {
+            if (! $model instanceof Model) {
+                continue;
+            }
+
+            if (! in_array(HasSlugHistory::class, class_uses_recursive($model), true)) {
+                continue;
+            }
+
+            /** @var string $slugColumn */
+            $slugColumn = $model->getAttributeToSaveSlugTo(); // @phpstan-ignore method.notFound
+
+            // @phpstan-ignore-next-line cast.string
+            $currentSlug = (string) $model->getAttribute($slugColumn);
+            // @phpstan-ignore-next-line cast.string
+            $urlSlug = (string) ($route->originalParameters()[$paramName] ?? '');
+
+            if ($urlSlug === '') {
+                continue; // @codeCoverageIgnore
+            }
+
+            if ($urlSlug === $currentSlug) {
+                continue;
+            }
+
+            $path = $request->getPathInfo();
+            $newPath = preg_replace(
+                '#(^|/)'.preg_quote($urlSlug, '#').'(/|$)#',
+                '$1'.$currentSlug.'$2',
+                $path
+            ) ?? $path;
+
+            if ($newPath === $path) {
+                continue; // @codeCoverageIgnore
+            }
+
+            $query = $request->getQueryString();
+            $redirectUrl = $newPath.($query !== null ? '?'.$query : '');
+
+            $status = config('slugify.redirect_status', 301);
+
+            return new RedirectResponse($redirectUrl, is_int($status) ? $status : 301);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/SlugifyServiceProvider.php
+++ b/src/SlugifyServiceProvider.php
@@ -4,19 +4,29 @@ declare(strict_types=1);
 
 namespace Oliwol\Slugify;
 
+use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
 use Oliwol\Slugify\Console\SlugifyGenerateCommand;
+use Oliwol\Slugify\Http\Middleware\SlugRedirectMiddleware;
 
 final class SlugifyServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {
+        $this->mergeConfigFrom(__DIR__.'/../config/slugify.php', 'slugify');
+
         $this->loadTranslationsFrom(__DIR__.'/../lang', 'slugify');
+
+        $this->app->make(Router::class)->aliasMiddleware('slug.redirect', SlugRedirectMiddleware::class);
 
         if ($this->app->runningInConsole()) {
             $this->commands([
                 SlugifyGenerateCommand::class,
             ]);
+
+            $this->publishes([
+                __DIR__.'/../config/slugify.php' => config_path('slugify.php'),
+            ], 'slugify-config');
         }
 
         $this->publishes([

--- a/src/SlugifyServiceProvider.php
+++ b/src/SlugifyServiceProvider.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Oliwol\Slugify;
 
-use Illuminate\Database\Eloquent\Factories\Factory;                                                                                                                                
-use Illuminate\Database\Eloquent\Model;                            
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
 use Oliwol\Slugify\Console\SlugifyGenerateCommand;
-use Oliwol\Slugify\Http\Middleware\SlugRedirectMiddleware; 
+use Oliwol\Slugify\Http\Middleware\SlugRedirectMiddleware;
 
 final class SlugifyServiceProvider extends ServiceProvider
 {

--- a/tests/Unit/HasSlugHistoryTest.php
+++ b/tests/Unit/HasSlugHistoryTest.php
@@ -113,6 +113,15 @@ it('does not record history when slug resolves to same value', function (): void
     expect($post->slugHistory)->toHaveCount(0);
 });
 
+it('resolves route binding by primary key when field is null and route key is not the slug column', function (): void {
+    $post = PostWithSlugHistory::create(['title' => 'Hello World']);
+
+    $found = (new PostWithSlugHistory)->resolveRouteBinding($post->getKey());
+
+    expect($found)->not->toBeNull();
+    expect($found->getKey())->toBe($post->getKey());
+});
+
 it('slug history entry belongs to the sluggable model', function (): void {
     $post = PostWithSlugHistory::create(['title' => 'Hello World']);
 

--- a/tests/Unit/SlugRedirectMiddlewareTest.php
+++ b/tests/Unit/SlugRedirectMiddlewareTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Support\Facades\Route;
+use Tests\Models\PostWithSlugHistory;
+use Tests\Models\UserWithAttribute;
+
+beforeEach(function (): void {
+    Route::get('/posts/{post:slug}', fn (PostWithSlugHistory $post) => response()->json(['slug' => $post->slug]))
+        ->middleware([SubstituteBindings::class, 'slug.redirect'])
+        ->name('posts.show');
+
+    Route::get('/users/{user}', fn (UserWithAttribute $user) => response()->json(['slug' => $user->slug]))
+        ->middleware([SubstituteBindings::class, 'slug.redirect']);
+});
+
+it('passes through when the slug is current', function (): void {
+    $post = PostWithSlugHistory::create(['title' => 'Hello World']);
+
+    $this->getJson('/posts/hello-world')
+        ->assertOk()
+        ->assertJson(['slug' => 'hello-world']);
+});
+
+it('redirects 301 when accessing a historical slug', function (): void {
+    $post = PostWithSlugHistory::create(['title' => 'Hello World']);
+    $post->update(['title' => 'Updated Title']);
+
+    $this->get('/posts/hello-world')
+        ->assertRedirect('/posts/updated-title')
+        ->assertStatus(301);
+});
+
+it('redirect target preserves the query string', function (): void {
+    $post = PostWithSlugHistory::create(['title' => 'Hello World']);
+    $post->update(['title' => 'Updated Title']);
+
+    $this->get('/posts/hello-world?ref=newsletter')
+        ->assertRedirect('/posts/updated-title?ref=newsletter');
+});
+
+it('passes through for models without HasSlugHistory', function (): void {
+    $user = UserWithAttribute::create(['name' => 'John Doe']);
+
+    $this->getJson('/users/'.$user->id)
+        ->assertOk()
+        ->assertJson(['slug' => 'john-doe']);
+});
+
+it('passes through when route parameter is not a model', function (): void {
+    Route::get('/items/{id}', fn (string $id) => response()->json(['id' => $id]))
+        ->middleware(['slug.redirect']);
+
+    $this->getJson('/items/42')
+        ->assertOk()
+        ->assertJson(['id' => '42']);
+});
+
+it('uses the configured redirect status code', function (): void {
+    config(['slugify.redirect_status' => 302]);
+
+    $post = PostWithSlugHistory::create(['title' => 'Hello World']);
+    $post->update(['title' => 'Updated Title']);
+
+    $this->get('/posts/hello-world')
+        ->assertRedirect('/posts/updated-title')
+        ->assertStatus(302);
+});


### PR DESCRIPTION
Introduces SlugRedirectMiddleware and resolveRouteBinding in HasSlugHistory so historical slugs transparently redirect to the current canonical URL. Adds publishable config for configurable redirect status code.