### PR TITLE
feat: ID-anchored slugs (appendId) (#55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ The `#[Slugify]` attribute accepts the following parameters:
 * `maxLength` (optional) — maximum number of characters for the slug. Truncates at word boundaries. Defaults to `null` (no limit).
 * `regenerateOnUpdate` (optional) — whether to regenerate the slug when the source attribute changes on update. Defaults to `true`. Set to `false` to only generate slugs on creation (useful for SEO).
 * `routeBinding` (optional) — when `true`, automatically sets `getRouteKeyName()` to the slug column. Requires `to:` to be set explicitly. Defaults to `false`.
+* `appendId` (optional) — when `true`, the route key becomes `{slug}-{id}` (e.g. `hello-world-5`) and the model resolves by the ID suffix, so slugs can change without breaking links. Stale slugs issue a `308` canonical redirect via the `slug.redirect` middleware. Requires the `HasSlug` trait. Defaults to `false`. See [ID-Anchored Slugs](https://oliwol.github.io/laravel-slugify/guide/id-anchored-slugs).
 
 ```php
 use Oliwol\Slugify\HasSlug;

--- a/config/slugify.php
+++ b/config/slugify.php
@@ -14,6 +14,15 @@ return [
     'redirect_status' => 301,
 
     /*
+     * HTTP status code used for the canonical redirect when an ID-anchored slug
+     * (#[Slugify(appendId: true)]) in the URL no longer matches the current slug.
+     *
+     * 308 — Permanent redirect that preserves the request method (recommended)
+     * 301 — Permanent redirect
+     */
+    'id_anchored_redirect_status' => 308,
+
+    /*
      * Models that should have slugs generated automatically without using the HasSlug trait.
      * Add the fully qualified class names of your Eloquent models here.
      * Each model must have a #[Slugify] attribute to configure slug generation.

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -26,6 +26,7 @@ export default defineConfig({
           { text: 'Getting Started', link: '/guide/getting-started' },
           { text: 'Configuration', link: '/guide/configuration' },
           { text: 'Features', link: '/guide/features' },
+          { text: 'ID-Anchored Slugs', link: '/guide/id-anchored-slugs' },
           { text: 'Migrating from Spatie', link: '/guide/migrating-from-spatie' },
         ],
       },

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -151,6 +151,7 @@ class Post extends Model
 | `maxLength()` | `int` | Max length, truncated at word boundaries |
 | `regenerateOnUpdate()` | `bool` | Whether to regenerate on update (default `true`) |
 | `routeBinding()` | `bool` | Use the slug column for route binding (requires `to()`) |
+| `appendId()` | `bool` | Anchor the route key to the primary key (`{slug}-{id}`) — see [ID-Anchored Slugs](/guide/id-anchored-slugs) |
 
 The `from()` closure receives the model instance and is the only way to combine related-model data or apply custom logic, since attributes cannot hold callables. As with method sources, a closure source skips dirty detection — the slug is regenerated on every save unless `regenerateOnUpdate(false)` is set.
 

--- a/docs/guide/id-anchored-slugs.md
+++ b/docs/guide/id-anchored-slugs.md
@@ -1,0 +1,96 @@
+# ID-Anchored Slugs
+
+ID-anchored slugs combine the slug with the model's primary key into a single route key (`/posts/hello-world-5`). The **ID** is what actually resolves the model, so the slug can change freely without ever breaking a link. When someone visits an old URL, a canonical redirect points them to the current one.
+
+This is our take on the same problem Spatie solves with "Self-Healing URLs" — different name, same value.
+
+## Enabling
+
+Set `appendId: true` on the `#[Slugify]` attribute. The `HasSlug` trait is **required** (the feature overrides the route-key methods, so attribute-only models cannot use it):
+
+```php
+use Oliwol\Slugify\HasSlug;
+use Oliwol\Slugify\Slugify;
+
+#[Slugify(from: 'title', to: 'slug', appendId: true)]
+class Post extends Model
+{
+    use HasSlug; // required for appendId
+}
+```
+
+Or via the fluent [`SlugConfig`](/guide/configuration) API:
+
+```php
+use Oliwol\Slugify\SlugConfig;
+
+public function slugConfig(): SlugConfig
+{
+    return SlugConfig::create()
+        ->from('title')
+        ->to('slug')
+        ->appendId();
+}
+```
+
+## How it works
+
+- `getRouteKey()` returns `{slug}-{id}` (e.g. `hello-world-5`), so `route('posts.show', $post)` generates the anchored URL automatically.
+- `resolveRouteBindingQuery()` extracts the trailing number as the primary key and resolves the model by ID — the slug part is ignored for resolution.
+- The `slug.redirect` middleware compares the slug in the URL with the current route key and issues a canonical redirect when they differ.
+
+```php
+use Illuminate\Support\Facades\Route;
+
+Route::get('/posts/{post}', fn (Post $post) => view('posts.show', compact('post')))
+    ->middleware(['slug.redirect'])
+    ->name('posts.show');
+```
+
+```
+GET /posts/hello-world-5      → 200 OK
+# title changed to "Updated Title":
+GET /posts/hello-world-5      → 308 → /posts/updated-title-5
+```
+
+The redirect preserves the query string. Its status defaults to `308` (Permanent Redirect) and is configurable in `config/slugify.php`:
+
+```php
+'id_anchored_redirect_status' => 308,
+```
+
+## Clean slugs, no increment suffix
+
+Because the primary key already makes every URL unique, the slug itself stays clean — no `-2` uniqueness suffix is appended even for duplicate titles:
+
+```php
+$a = Post::create(['title' => 'Same Title']); // slug: "same-title", URL: same-title-1
+$b = Post::create(['title' => 'Same Title']); // slug: "same-title", URL: same-title-2
+```
+
+`maxLength` still applies to the slug part.
+
+## Slugs ending in a number
+
+If the slug ends in a digit, the route key simply has two trailing numbers — the **last** one is always the ID, which keeps resolution unambiguous:
+
+```php
+$post = Post::create(['title' => 'Hello World 2']); // id 7
+$post->getRouteKey(); // "hello-world-2-7" → resolves to id 7
+```
+
+## ID-anchored slugs vs. slug history
+
+Both solve "links shouldn't break when a slug changes". Pick based on your URL and maintenance needs:
+
+| | `appendId: true` | [`HasSlugHistory`](/guide/features#slug-history) |
+|---|---|---|
+| URL shape | contains the ID (`hello-world-5`) | clean (`hello-world`) |
+| Extra DB table | none | `slug_history` |
+| Maintenance | zero | history rows accumulate |
+| Audit trail | no | full history of past slugs |
+| Redirect status | `308` (configurable) | `301` (configurable) |
+
+Use **`appendId`** when you want zero-maintenance redirects without an extra table and don't mind the ID in the URL. Use **`HasSlugHistory`** when you need clean, ID-free URLs and a full audit trail.
+
+The two features are orthogonal and can both be active on the same model.

--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -176,8 +176,41 @@ trait HasSlug
         return $this->getKeyName();
     }
 
+    public function isIdAnchored(): bool
+    {
+        $config = $this->resolveSlugConfig();
+
+        return $config instanceof SlugConfig && $config->usesIdAnchoring();
+    }
+
+    public function getRouteKey()
+    {
+        if (! $this->isIdAnchored()) {
+            return $this->getAttribute($this->getRouteKeyName());
+        }
+
+        $slug = $this->getAttribute($this->getAttributeToSaveSlugTo());
+
+        return (is_string($slug) ? $slug : '').'-'.$this->getKey();
+    }
+
+    public function resolveRouteBindingQuery($query, $value, $field = null)
+    {
+        if ($this->isIdAnchored() && $field === null) {
+            return $query->where($this->getKeyName(), $this->extractIdFromRouteKey($value));
+        }
+
+        return $query->where($field ?? $this->getRouteKeyName(), $value);
+    }
+
     public function incrementSlugIfExists(string $slug): string
     {
+        // With ID-anchored slugs the primary key already makes every URL unique,
+        // so the slug itself stays clean — no numeric increment is appended.
+        if ($this->isIdAnchored()) {
+            return $this->truncateSlug($slug);
+        }
+
         $slug = $this->truncateSlug($slug);
         $original = $slug;
         $separator = $this->getSlugSeparator();
@@ -293,6 +326,20 @@ trait HasSlug
             ->where($this->getAttributeToSaveSlugTo(), $slug)
             ->whereNot($this->getKeyName(), $this->getKey())
             ->exists();
+    }
+
+    private function extractIdFromRouteKey(mixed $routeKey): ?string
+    {
+        if (! is_string($routeKey)) {
+            return null;
+        }
+
+        // The trailing number is always the primary key (appendId builds "{slug}-{id}").
+        if (preg_match('/(\d+)$/', $routeKey, $matches) === 1) {
+            return $matches[1];
+        }
+
+        return null;
     }
 
     private function resolveSlugConfig(): ?SlugConfig

--- a/src/Http/Middleware/SlugRedirectMiddleware.php
+++ b/src/Http/Middleware/SlugRedirectMiddleware.php
@@ -25,6 +25,33 @@ final class SlugRedirectMiddleware
                 continue;
             }
 
+            // @phpstan-ignore-next-line cast.string
+            $urlValue = (string) ($route->originalParameters()[$paramName] ?? '');
+
+            if ($urlValue === '') {
+                continue; // @codeCoverageIgnore
+            }
+
+            // ID-anchored slugs (#[Slugify(appendId: true)]): the route key is "{slug}-{id}".
+            // When the slug part is stale, redirect to the canonical "{currentSlug}-{id}".
+            if (method_exists($model, 'isIdAnchored') && $model->isIdAnchored()) {
+                // @phpstan-ignore-next-line cast.string
+                $canonical = (string) $model->getRouteKey();
+
+                if ($urlValue === $canonical) {
+                    continue;
+                }
+
+                $status = config('slugify.id_anchored_redirect_status', 308);
+                $redirect = $this->buildRedirect($request, $urlValue, $canonical, is_int($status) ? $status : 308);
+
+                if ($redirect instanceof RedirectResponse) {
+                    return $redirect;
+                }
+
+                continue; // @codeCoverageIgnore
+            }
+
             if (! in_array(HasSlugHistory::class, class_uses_recursive($model), true)) {
                 continue;
             }
@@ -34,36 +61,38 @@ final class SlugRedirectMiddleware
 
             // @phpstan-ignore-next-line cast.string
             $currentSlug = (string) $model->getAttribute($slugColumn);
-            // @phpstan-ignore-next-line cast.string
-            $urlSlug = (string) ($route->originalParameters()[$paramName] ?? '');
 
-            if ($urlSlug === '') {
-                continue; // @codeCoverageIgnore
-            }
-
-            if ($urlSlug === $currentSlug) {
+            if ($urlValue === $currentSlug) {
                 continue;
             }
 
-            $path = $request->getPathInfo();
-            $newPath = preg_replace(
-                '#(^|/)'.preg_quote($urlSlug, '#').'(/|$)#',
-                '$1'.$currentSlug.'$2',
-                $path
-            ) ?? $path;
-
-            if ($newPath === $path) {
-                continue; // @codeCoverageIgnore
-            }
-
-            $query = $request->getQueryString();
-            $redirectUrl = $newPath.($query !== null ? '?'.$query : '');
-
             $status = config('slugify.redirect_status', 301);
+            $redirect = $this->buildRedirect($request, $urlValue, $currentSlug, is_int($status) ? $status : 301);
 
-            return new RedirectResponse($redirectUrl, is_int($status) ? $status : 301);
+            if ($redirect instanceof RedirectResponse) {
+                return $redirect;
+            }
         }
 
         return $next($request);
+    }
+
+    private function buildRedirect(Request $request, string $from, string $to, int $status): ?RedirectResponse
+    {
+        $path = $request->getPathInfo();
+        $newPath = preg_replace(
+            '#(^|/)'.preg_quote($from, '#').'(/|$)#',
+            '$1'.$to.'$2',
+            $path
+        ) ?? $path;
+
+        if ($newPath === $path) {
+            return null; // @codeCoverageIgnore
+        }
+
+        $query = $request->getQueryString();
+        $redirectUrl = $newPath.($query !== null ? '?'.$query : '');
+
+        return new RedirectResponse($redirectUrl, $status);
     }
 }

--- a/src/SlugConfig.php
+++ b/src/SlugConfig.php
@@ -23,6 +23,8 @@ final class SlugConfig
 
     private bool $routeBinding = false;
 
+    private bool $appendId = false;
+
     public static function create(): self
     {
         return new self;
@@ -37,6 +39,7 @@ final class SlugConfig
         $config->maxLength = $attribute->maxLength;
         $config->regenerateOnUpdate = $attribute->regenerateOnUpdate;
         $config->routeBinding = $attribute->routeBinding;
+        $config->appendId = $attribute->appendId;
 
         return $config;
     }
@@ -86,6 +89,13 @@ final class SlugConfig
         return $this;
     }
 
+    public function appendId(bool $appendId = true): self
+    {
+        $this->appendId = $appendId;
+
+        return $this;
+    }
+
     /**
      * @return string|array<int, string>|Closure
      */
@@ -117,5 +127,10 @@ final class SlugConfig
     public function usesRouteBinding(): bool
     {
         return $this->routeBinding;
+    }
+
+    public function usesIdAnchoring(): bool
+    {
+        return $this->appendId;
     }
 }

--- a/src/Slugify.php
+++ b/src/Slugify.php
@@ -19,5 +19,6 @@ final readonly class Slugify
         public ?int $maxLength = null,
         public bool $regenerateOnUpdate = true,
         public bool $routeBinding = false,
+        public bool $appendId = false,
     ) {}
 }

--- a/tests/Models/PostWithAppendId.php
+++ b/tests/Models/PostWithAppendId.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Oliwol\Slugify\HasSlug;
+use Oliwol\Slugify\Slugify;
+
+#[Slugify(from: 'title', to: 'slug', appendId: true)]
+final class PostWithAppendId extends Model
+{
+    use HasSlug;
+
+    public $timestamps = false;
+
+    protected $table = 'posts_with_slug';
+
+    protected $guarded = [];
+}

--- a/tests/Unit/AppendIdTest.php
+++ b/tests/Unit/AppendIdTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Support\Facades\Route;
+use Tests\Models\PostWithAppendId;
+use Tests\Models\UserWithAttribute;
+use Tests\Models\UserWithRouteBinding;
+
+beforeEach(function (): void {
+    Route::get('/posts/{post}', fn (PostWithAppendId $post) => response()->json([
+        'id' => $post->id,
+        'slug' => $post->slug,
+    ]))
+        ->middleware([SubstituteBindings::class, 'slug.redirect'])
+        ->name('posts.show');
+});
+
+it('builds a route key combining slug and primary key', function (): void {
+    $post = PostWithAppendId::create(['title' => 'Hello World']);
+
+    expect($post->getRouteKey())->toBe('hello-world-'.$post->id);
+});
+
+it('keeps the slug clean for duplicate titles (no numeric increment)', function (): void {
+    $first = PostWithAppendId::create(['title' => 'Same Title']);
+    $second = PostWithAppendId::create(['title' => 'Same Title']);
+
+    expect($first->fresh()->slug)->toBe('same-title')
+        ->and($second->fresh()->slug)->toBe('same-title');
+});
+
+it('resolves the model by the ID suffix in the route key', function (): void {
+    $post = PostWithAppendId::create(['title' => 'Hello World']);
+
+    $this->getJson('/posts/hello-world-'.$post->id)
+        ->assertOk()
+        ->assertJson(['id' => $post->id, 'slug' => 'hello-world']);
+});
+
+it('passes through without redirect when the slug is current', function (): void {
+    $post = PostWithAppendId::create(['title' => 'Hello World']);
+
+    $this->get('/posts/hello-world-'.$post->id)
+        ->assertOk();
+});
+
+it('redirects 308 to the canonical URL when the slug is stale', function (): void {
+    $post = PostWithAppendId::create(['title' => 'Hello World']);
+    $post->update(['title' => 'Updated Title']);
+
+    $this->get('/posts/hello-world-'.$post->id)
+        ->assertRedirect('/posts/updated-title-'.$post->id)
+        ->assertStatus(308);
+});
+
+it('preserves the query string on a canonical redirect', function (): void {
+    $post = PostWithAppendId::create(['title' => 'Hello World']);
+    $post->update(['title' => 'Updated Title']);
+
+    $this->get('/posts/hello-world-'.$post->id.'?ref=newsletter')
+        ->assertRedirect('/posts/updated-title-'.$post->id.'?ref=newsletter');
+});
+
+it('resolves correctly when the slug itself ends in a number', function (): void {
+    $post = PostWithAppendId::create(['title' => 'Hello World 2']);
+
+    expect($post->getRouteKey())->toBe('hello-world-2-'.$post->id);
+
+    $this->getJson('/posts/hello-world-2-'.$post->id)
+        ->assertOk()
+        ->assertJson(['id' => $post->id, 'slug' => 'hello-world-2']);
+});
+
+it('reports isIdAnchored true only when appendId is enabled', function (): void {
+    expect((new PostWithAppendId)->isIdAnchored())->toBeTrue()
+        ->and((new UserWithAttribute)->isIdAnchored())->toBeFalse();
+});
+
+it('returns the plain route key when appendId is disabled', function (): void {
+    $user = UserWithRouteBinding::create(['name' => 'John Doe']);
+
+    expect($user->getRouteKey())->toBe('john-doe');
+});
+
+it('does not resolve a model when the route key has no ID suffix', function (): void {
+    PostWithAppendId::create(['title' => 'Hello World']);
+
+    $this->get('/posts/hello-world')->assertNotFound();
+});
+
+it('extracts no ID when the route value is not a string', function (): void {
+    $post = new PostWithAppendId;
+
+    $result = $post->resolveRouteBindingQuery(PostWithAppendId::query(), ['not-a-string']);
+
+    expect($result->first())->toBeNull();
+});

--- a/tests/Unit/SlugConfigTest.php
+++ b/tests/Unit/SlugConfigTest.php
@@ -16,14 +16,16 @@ it('builds a configuration fluently', function (): void {
         ->separator('_')
         ->maxLength(30)
         ->regenerateOnUpdate(false)
-        ->routeBinding();
+        ->routeBinding()
+        ->appendId();
 
     expect($config->getFrom())->toBe('title')
         ->and($config->getTo())->toBe('slug')
         ->and($config->getSeparator())->toBe('_')
         ->and($config->getMaxLength())->toBe(30)
         ->and($config->shouldRegenerateOnUpdate())->toBeFalse()
-        ->and($config->usesRouteBinding())->toBeTrue();
+        ->and($config->usesRouteBinding())->toBeTrue()
+        ->and($config->usesIdAnchoring())->toBeTrue();
 });
 
 it('exposes sensible defaults', function (): void {
@@ -34,7 +36,8 @@ it('exposes sensible defaults', function (): void {
         ->and($config->getSeparator())->toBeNull()
         ->and($config->getMaxLength())->toBeNull()
         ->and($config->shouldRegenerateOnUpdate())->toBeTrue()
-        ->and($config->usesRouteBinding())->toBeFalse();
+        ->and($config->usesRouteBinding())->toBeFalse()
+        ->and($config->usesIdAnchoring())->toBeFalse();
 });
 
 it('creates a configuration from a Slugify attribute', function (): void {
@@ -45,6 +48,7 @@ it('creates a configuration from a Slugify attribute', function (): void {
         maxLength: 10,
         regenerateOnUpdate: false,
         routeBinding: true,
+        appendId: true,
     ));
 
     expect($config->getFrom())->toBe('name')
@@ -52,7 +56,8 @@ it('creates a configuration from a Slugify attribute', function (): void {
         ->and($config->getSeparator())->toBe('+')
         ->and($config->getMaxLength())->toBe(10)
         ->and($config->shouldRegenerateOnUpdate())->toBeFalse()
-        ->and($config->usesRouteBinding())->toBeTrue();
+        ->and($config->usesRouteBinding())->toBeTrue()
+        ->and($config->usesIdAnchoring())->toBeTrue();
 });
 
 it('creates a slug via SlugConfig with custom separator', function (): void {


### PR DESCRIPTION
## Summary

Adds ID-anchored slugs via `appendId` on the `#[Slugify]` attribute (and `SlugConfig`). When enabled, the route key becomes `{slug}-{id}` and the model resolves by the trailing ID — so slugs can change freely without breaking links. Stale slugs trigger a configurable **308** canonical redirect via the existing `slug.redirect` middleware. This is our take on the same problem Spatie solves with "Self-Healing URLs".

```php
#[Slugify(from: 'title', to: 'slug', appendId: true)]
class Post extends Model
{
    use HasSlug; // required — appendId overrides the route-key methods
}

// /posts/hello-world-5 → 200
// after title change:  /posts/hello-world-5 → 308 → /posts/updated-title-5
```

## Changes

- **`HasSlug`** — `isIdAnchored()`, `getRouteKey()` → `{slug}-{id}`, `resolveRouteBindingQuery()` extracts the ID suffix (regex `/(\d+)$/`, last number is always the PK), and `incrementSlugIfExists()` becomes a no-op (the ID keeps URLs unique, so the slug stays clean; `maxLength` still applies)
- **`SlugRedirectMiddleware`** — shared `buildRedirect()` helper now serves both the appendId (308) and `HasSlugHistory` (301) cases
- **`Slugify` / `SlugConfig`** — new `appendId` parameter / `appendId()` + `usesIdAnchoring()`
- **config** — new `id_anchored_redirect_status` key (default `308`)
- **Docs** — new "ID-Anchored Slugs" VitePress page with a comparison vs `HasSlugHistory`, README + configuration updates

## Edge cases covered

- Slugs ending in a number (`hello-world-2-7` resolves to id 7 — last number wins)
- No numeric increment suffix for duplicate titles
- Route key without an ID suffix → not found
- Non-string route value → no resolution

## Checks

Full suite green: Lint, Rector, PHPStan (level max), Arch, 195 unit tests, 100% coverage.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)