### PR TITLE
docs: update VitePress site for v2 (#59)

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -23,12 +23,13 @@ export default defineConfig({
       {
         text: 'Guide',
         items: [
+          { text: 'Why Laravel Slugify?', link: '/guide/why' },
           { text: 'Getting Started', link: '/guide/getting-started' },
           { text: 'Configuration', link: '/guide/configuration' },
           { text: 'Features', link: '/guide/features' },
           { text: 'ID-Anchored Slugs', link: '/guide/id-anchored-slugs' },
-          { text: 'Upgrading (v1 → v2)', link: '/guide/upgrading' },
           { text: 'Migrating from Spatie', link: '/guide/migrating-from-spatie' },
+          { text: 'Upgrading (v1 → v2)', link: '/guide/upgrading' },
         ],
       },
       {

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -10,10 +10,42 @@
     maxLength: null,          // ?int — default: null (no limit)
     regenerateOnUpdate: true, // bool — default: true
     routeBinding: false,      // bool — default: false
+    appendId: false,          // bool — default: false
 )]
 ```
 
 When `routeBinding: true` is set (and `to` is specified), `getRouteKeyName()` returns the slug column so Laravel resolves route parameters by slug automatically.
+
+When `appendId: true` is set, the route key becomes `{slug}-{id}` and the model resolves by the trailing ID, with a `308` canonical redirect for stale slugs. Requires the `HasSlug` trait. See [ID-Anchored Slugs](/guide/id-anchored-slugs).
+
+## `SlugConfig`
+
+A fluent, mutable builder returned from a `slugConfig()` method on the model as an alternative to the `#[Slugify]` attribute. Use it when you need a closure source or conditional logic the attribute can't express. See [Configuration](/guide/configuration#via-the-fluent-slugconfig-api).
+
+```php
+use Oliwol\Slugify\SlugConfig;
+
+SlugConfig::create()
+    ->from('title')          // string|array|Closure — closure receives the model
+    ->to('slug')             // string
+    ->separator('-')         // string
+    ->maxLength(60)          // int
+    ->regenerateOnUpdate()   // bool — default true
+    ->routeBinding()         // bool — default true when called
+    ->appendId();            // bool — default true when called
+```
+
+| Builder method | Getter |
+|---|---|
+| `from(string\|array\|Closure)` | `getFrom(): string\|array\|Closure` |
+| `to(string)` | `getTo(): ?string` |
+| `separator(string)` | `getSeparator(): ?string` |
+| `maxLength(int)` | `getMaxLength(): ?int` |
+| `regenerateOnUpdate(bool = true)` | `shouldRegenerateOnUpdate(): bool` |
+| `routeBinding(bool = true)` | `usesRouteBinding(): bool` |
+| `appendId(bool = true)` | `usesIdAnchoring(): bool` |
+
+`SlugConfig::fromAttribute(Slugify $attribute): self` builds a config from an attribute — used internally to normalize both configuration sources.
 
 ## HasSlug Trait
 
@@ -71,11 +103,27 @@ Return the route key name. When `routeBinding: true` is configured and `to` is s
 
 Return whether the model is configured to use the slug column for route model binding.
 
+#### `isIdAnchored(): bool`
+
+Return whether ID-anchored slugs (`appendId`) are enabled for this model.
+
+#### `getRouteKey()`
+
+When `appendId` is enabled, returns `{slug}-{id}`. Otherwise returns the standard Eloquent route key (`getAttribute(getRouteKeyName())`).
+
+#### `resolveRouteBindingQuery($query, $value, $field = null)`
+
+When `appendId` is enabled and no explicit field is given, resolves the model by the trailing ID extracted from the route value. Otherwise behaves like the default Eloquent binding query.
+
 ### Overridable Methods
 
-#### `getAttributeToCreateSlugFrom(): string|array`
+#### `slugConfig(): SlugConfig`
 
-Return the source attribute name(s) or method name. Override to customize.
+Optional. Return a [`SlugConfig`](#slugconfig) to configure slug generation fluently — takes precedence over the `#[Slugify]` attribute. Define this method when you need closures or conditional logic.
+
+#### `getAttributeToCreateSlugFrom(): string|array|Closure`
+
+Return the source attribute name(s), method name, or a closure. Overriding this takes precedence over both `slugConfig()` and the `#[Slugify]` attribute.
 
 #### `getAttributeToSaveSlugTo(): string`
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -10,7 +10,30 @@ composer require oliwol/laravel-slugify
 
 ## Quick Start
 
-### Using the PHP Attribute (recommended)
+### Attribute-only (the simplest setup)
+
+Add the `#[Slugify]` attribute and register the model in `config/slugify.php` — no trait required. The package generates slugs automatically on save.
+
+```php
+use Oliwol\Slugify\Slugify;
+
+#[Slugify(from: 'title', to: 'slug')]
+class Post extends Model
+{
+    // No trait required
+}
+```
+
+```php
+// config/slugify.php (publish with: php artisan vendor:publish --tag=slugify-config)
+'models' => [
+    App\Models\Post::class,
+],
+```
+
+### With the `HasSlug` trait
+
+Add the trait when you need `findBySlug()`, [slug history](/guide/features#slug-history), [translatable slugs](/guide/features#translatable-slugs), [route binding](/guide/features#route-model-binding) or [ID-anchored slugs](/guide/id-anchored-slugs). No config registration is needed when using the trait.
 
 ```php
 use Oliwol\Slugify\HasSlug;
@@ -23,29 +46,12 @@ class Post extends Model
 }
 ```
 
-### Using method overrides
+### Closures and complex configuration
 
-```php
-use Oliwol\Slugify\HasSlug;
-
-class Post extends Model
-{
-    use HasSlug;
-
-    public function getAttributeToCreateSlugFrom(): string|array
-    {
-        return 'title';
-    }
-
-    public function getRouteKeyName(): string
-    {
-        return 'slug';
-    }
-}
-```
+When a PHP attribute isn't expressive enough — closures, conditional logic — return a [`SlugConfig`](/guide/configuration#via-the-fluent-slugconfig-api) from a `slugConfig()` method, or override the configuration methods directly.
 
 ::: tip Priority
-Method overrides always take precedence over the `#[Slugify]` attribute.
+Method overrides > `slugConfig()` > `#[Slugify]` attribute.
 :::
 
 ## Migration Setup

--- a/docs/guide/why.md
+++ b/docs/guide/why.md
@@ -1,0 +1,42 @@
+# Why Laravel Slugify?
+
+Laravel Slugify generates clean, unique slugs for Eloquent models with as little ceremony as possible — a single PHP attribute, no boilerplate, sensible defaults.
+
+It covers the same ground as [`spatie/laravel-sluggable`](https://github.com/spatie/laravel-sluggable), a mature and excellent package. This page is an honest look at what Laravel Slugify offers and where each package is stronger, so you can pick the right tool.
+
+## Design principles
+
+- **Attribute-first.** Most models need one line: `#[Slugify(from: 'title', to: 'slug')]`. The trait is optional — add it only when you need its query helpers or routing behavior.
+- **Batteries included, opt-in.** Slug history, events, translatable slugs, ID-anchored URLs and a bulk Artisan command ship in the box, but nothing activates until you ask for it.
+- **Rich attribute.** Separator, max length, regeneration control, route binding and ID-anchoring all live on the attribute itself — no fluent builder required for the common cases.
+
+## What sets it apart
+
+- **Slug history with timestamps** (`HasSlugHistory`) — a full audit trail of past slugs plus ready-made `301` redirects.
+- **Lifecycle events** — `SlugGenerated` and `SlugUpdated` let you hook into slug changes (e.g. to record redirects or bust caches).
+- **Artisan bulk command** — `slugify:generate` backfills or regenerates slugs across existing records, safely, in chunks.
+- **A configuration-rich attribute** — options that other packages put behind a fluent builder are available inline.
+
+## Honest comparison with Spatie v4
+
+Since Spatie v4, the two packages overlap heavily — both have attribute-only configuration, a fluent config API, translatable slugs and self-healing / ID-anchored URLs.
+
+| | Laravel Slugify v2 | Spatie v4 |
+|---|---|---|
+| Slug history with timestamps | ✅ | ❌ |
+| Lifecycle events | ✅ | ❌ |
+| Artisan bulk generation | ✅ | ❌ |
+| Options on the attribute itself | ✅ (separator, maxLength, …) | ⚠️ `from` / `to` / `selfHealing` only |
+| Overridable actions | ❌ | ✅ |
+| Fluent config API | ✅ `SlugConfig` | ✅ `SlugOptions` |
+| ID-anchored URLs | ✅ `appendId` | ✅ "Self-Healing" |
+
+**Where Spatie v4 is stronger:** overridable actions — you can swap its slug generator or self-healing resolver for your own class via config. Laravel Slugify has no equivalent today; use a closure source or events instead.
+
+If those specific trade-offs don't matter to you, both packages will serve you well. For a complete, side-by-side migration walkthrough, see [Migrating from Spatie](/guide/migrating-from-spatie).
+
+## Next steps
+
+- [Getting Started](/guide/getting-started) — install and create your first slug
+- [Configuration](/guide/configuration) — the attribute and the `SlugConfig` API
+- [Features](/guide/features) — history, events, translatable slugs, validation and more

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,11 +4,14 @@ layout: home
 hero:
   name: Laravel Slugify
   text: Clean, automatic slugs for Eloquent
-  tagline: A tiny trait that gives your models clean, automatic slugs — without setup, ceremony, or extra weight.
+  tagline: Clean, automatic slugs from a single PHP attribute — the trait is optional, the defaults are sensible.
   actions:
     - theme: brand
       text: Get Started
       link: /guide/getting-started
+    - theme: alt
+      text: Why Laravel Slugify?
+      link: /guide/why
     - theme: alt
       text: View on GitHub
       link: https://github.com/oliwol/laravel-slugify
@@ -16,7 +19,10 @@ hero:
 features:
   - icon: 🏷️
     title: "#[Slugify] Attribute"
-    details: Configure slug generation with a simple PHP attribute — no boilerplate, no config files.
+    details: Configure slug generation with a single PHP attribute — no trait required. Reach for the fluent SlugConfig API when you need closures.
+  - icon: 🔗
+    title: ID-Anchored URLs
+    details: Opt into appendId for self-healing /post-5 style URLs that survive slug changes with a 308 canonical redirect.
   - icon: 🔢
     title: Unique Slugs
     details: Automatic uniqueness with intelligent incrementing (my-post, my-post-2, my-post-3).


### PR DESCRIPTION
## Summary

Rounds out the VitePress documentation site for the v2 feature set. Much of the site was already updated by earlier v2 PRs (Configuration + SlugConfig, ID-Anchored Slugs page, Spatie v4 migration guide, Upgrade guide); this PR fills the remaining gaps.

## Changes

- **API Reference** — documents the `SlugConfig` class (builder methods + getter table), the `appendId` attribute parameter, the `slugConfig()` method, and the new `isIdAnchored()` / `getRouteKey()` / `resolveRouteBindingQuery()` methods; fixes the `getAttributeToCreateSlugFrom()` return type (`string|array|Closure`)
- **Getting Started** — leads with attribute-only usage as the default, then the `HasSlug` trait, then `SlugConfig` / method overrides
- **New "Why Laravel Slugify?" page** — design principles, differentiators, and an honest Spatie v4 comparison (including where Spatie is stronger)
- **Landing page** — attribute-first tagline, a "Why Laravel Slugify?" action, and an ID-anchored URLs feature tile
- **Sidebar** — reordered with "Why" first; upgrade guide accessible

## Acceptance criteria

- ✅ All new v2 features documented
- ✅ Attribute-only usage is the default in examples
- ✅ Spatie v4 comparison is accurate and honest
- ✅ Upgrade guide accessible from docs
- ✅ `vitepress build` passes with no dead links

## Note

The issue's *suggested* sidebar restructure (splitting `features.md` into seven sub-pages) was left out — it isn't part of the acceptance criteria and is a large, risky refactor of the existing single page. Can be done separately if wanted.

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)